### PR TITLE
Multi-Company unique table list and workspace export functionality

### DIFF
--- a/businessCentral/app/src/Communication.Codeunit.al
+++ b/businessCentral/app/src/Communication.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 82562 "ADLSE Communication"
         DefaultContainerName: Text;
         MaxSizeOfPayloadMiB: Integer;
         EmitTelemetry: Boolean;
+        LandingZoneOverride: Text;
         DeltaCdmManifestNameTxt: Label 'deltas.manifest.cdm.json', Locked = true;
         DataCdmManifestNameTxt: Label 'data.manifest.cdm.json', Locked = true;
         EntityManifestNameTemplateTxt: Label '%1.cdm.json', Locked = true, Comment = '%1 = Entity name';
@@ -170,10 +171,13 @@ codeunit 82562 "ADLSE Communication"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Companies Table", 'rm')]
     local procedure CreateDataBlob() Created: Boolean
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETable: Record "ADLSE Table";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEGen2Util: Codeunit "ADLSE Gen 2 Util";
         ADLSEExecution: Codeunit "ADLSE Execution";
@@ -198,9 +202,16 @@ codeunit 82562 "ADLSE Communication"
                 BlobContentLength := 0;
 
                 if (ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Open Mirroring") then begin
-                    ADLSETable.Get(TableID);
-                    ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
-                    ADLSETable.Modify(true);
+                    ADLSESyncCompanies.Get(CompanyName());
+                    if ADLSESyncCompanies.LandingZone <> '' then begin
+                        ADLSECompaniesTable.Get(TableID, CompanyName());
+                        ADLSECompaniesTable.ExportFileNumber := ADLSECompaniesTable.ExportFileNumber + 1;
+                        ADLSECompaniesTable.Modify(true);
+                    end else begin
+                        ADLSETable.Get(TableID);
+                        ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
+                        ADLSETable.Modify(true);
+                    end;
                     Commit(); // Because of multiple files in one session can be exported
                 end;
             end;
@@ -209,12 +220,22 @@ codeunit 82562 "ADLSE Communication"
             FileIdentifer := CreateGuid()
         else begin
             //https://learn.microsoft.com/en-us/fabric/database/mirrored-database/open-mirroring-landing-zone-format#data-file-and-format-in-the-landing-zone
-            ADLSETable.Get(TableID);
-            if ADLSETable.ExportFileNumber = 0 then begin
-                ADLSETable.ExportFileNumber := 1;
-                ADLSETable.Modify(true);
+            ADLSESyncCompanies.Get(CompanyName());
+            if ADLSESyncCompanies.LandingZone <> '' then begin
+                ADLSECompaniesTable.Get(TableID, CompanyName());
+                if ADLSECompaniesTable.ExportFileNumber = 0 then begin
+                    ADLSECompaniesTable.ExportFileNumber := 1;
+                    ADLSECompaniesTable.Modify(true);
+                end;
+                FileIdentiferTxt := Format(ADLSECompaniesTable.ExportFileNumber);
+            end else begin
+                ADLSETable.Get(TableID);
+                if ADLSETable.ExportFileNumber = 0 then begin
+                    ADLSETable.ExportFileNumber := 1;
+                    ADLSETable.Modify(true);
+                end;
+                FileIdentiferTxt := Format(ADLSETable.ExportFileNumber);
             end;
-            FileIdentiferTxt := Format(ADLSETable.ExportFileNumber);
             FileIdentiferTxt := FileIdentiferTxt.PadLeft(20, '0');
         end;
 
@@ -347,6 +368,11 @@ codeunit 82562 "ADLSE Communication"
         end;
     end;
 
+    procedure SetLandingZoneOverride(LandingZone: Text)
+    begin
+        LandingZoneOverride := LandingZone;
+    end;
+
     procedure UpdateCdmJsons(EntityJsonNeedsUpdate: Boolean; ManifestJsonsNeedsUpdate: Boolean)
     var
         ADLSESyncCompanies: Record "ADLSE Sync Companies";
@@ -355,20 +381,24 @@ codeunit 82562 "ADLSE Communication"
         LeaseID: Text;
         BlobPath: Text;
         BlobExists: Boolean;
+        ResolvedLandingZone: Text;
     begin
         ADLSESetup.ReadIsolation := IsolationLevel::UpdLock;
         ADLSESetup.GetSingleton();
 
-        //TODO create open morroring specific code for this
         // update entity json
         if EntityJsonNeedsUpdate then begin
             if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
-
-                ADLSESyncCompanies.Get(CompanyName());
-                if ADLSESyncCompanies.LandingZone <> '' then
-                    BlobPath := ADLSESyncCompanies.LandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
-                else
-                    BlobPath := ADLSESetup.LandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
+                if LandingZoneOverride <> '' then
+                    ResolvedLandingZone := LandingZoneOverride
+                else begin
+                    ADLSESyncCompanies.Get(CompanyName());
+                    if ADLSESyncCompanies.LandingZone <> '' then
+                        ResolvedLandingZone := ADLSESyncCompanies.LandingZone
+                    else
+                        ResolvedLandingZone := ADLSESetup.LandingZone;
+                end;
+                BlobPath := ResolvedLandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
             end
             else
                 BlobPath := GetBaseUrl() + StrSubstNo(CorpusJsonPathTxt, StrSubstNo(EntityManifestNameTemplateTxt, EntityName));

--- a/businessCentral/app/src/Communication.Codeunit.al
+++ b/businessCentral/app/src/Communication.Codeunit.al
@@ -48,6 +48,7 @@ codeunit 82562 "ADLSE Communication"
 
     local procedure GetBaseUrl(): Text
     var
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSESetup: Record "ADLSE Setup";
         ValidGuid: Guid;
     begin
@@ -66,7 +67,13 @@ codeunit 82562 "ADLSE Communication"
                 else
                     exit(StrSubstNo(MSFabricUrlGuidTxt, ADLSESetup.Workspace, ADLSESetup.Lakehouse));
             ADLSESetup."Storage Type"::"Open Mirroring":
-                exit(ADLSESetup.LandingZone);
+                begin
+                    ADLSESyncCompanies.Get(CompanyName());
+                    if ADLSESyncCompanies.LandingZone <> '' then
+                        exit(ADLSESyncCompanies.LandingZone)
+                    else
+                        exit(ADLSESetup.LandingZone);
+                end;
         end;
     end;
 
@@ -342,6 +349,7 @@ codeunit 82562 "ADLSE Communication"
 
     procedure UpdateCdmJsons(EntityJsonNeedsUpdate: Boolean; ManifestJsonsNeedsUpdate: Boolean)
     var
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSESetup: Record "ADLSE Setup";
         ADLSEGen2Util: Codeunit "ADLSE Gen 2 Util";
         LeaseID: Text;
@@ -354,8 +362,14 @@ codeunit 82562 "ADLSE Communication"
         //TODO create open morroring specific code for this
         // update entity json
         if EntityJsonNeedsUpdate then begin
-            if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then
-                BlobPath := ADLSESetup.LandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
+            if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then begin
+
+                ADLSESyncCompanies.Get(CompanyName());
+                if ADLSESyncCompanies.LandingZone <> '' then
+                    BlobPath := ADLSESyncCompanies.LandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
+                else
+                    BlobPath := ADLSESetup.LandingZone + StrSubstNo(CorpusJsonPathTxt, EntityName) + StrSubstNo(CorpusJsonPathTxt, '_metadata.json')
+            end
             else
                 BlobPath := GetBaseUrl() + StrSubstNo(CorpusJsonPathTxt, StrSubstNo(EntityManifestNameTemplateTxt, EntityName));
             if ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Azure Data Lake" then

--- a/businessCentral/app/src/CompaniesTable.Table.al
+++ b/businessCentral/app/src/CompaniesTable.Table.al
@@ -51,6 +51,13 @@ table 82572 "ADLSE Companies Table"
         {
             Caption = 'Last error';
         }
+        field(65; Include; Boolean)
+        {
+            Caption = 'Include';
+            ToolTip = 'Specifies whether this table is included in the data export process to Azure Data Lake Storage Explorer.';
+            InitValue = true;
+            DataClassification = CustomerContent;
+        }
     }
 
     keys

--- a/businessCentral/app/src/CompaniesTable.Table.al
+++ b/businessCentral/app/src/CompaniesTable.Table.al
@@ -58,6 +58,11 @@ table 82572 "ADLSE Companies Table"
             InitValue = true;
             DataClassification = CustomerContent;
         }
+        field(70; ExportFileNumber; Integer)
+        {
+            Caption = 'Export File Number';
+            DataClassification = CustomerContent;
+        }
     }
 
     keys
@@ -104,7 +109,7 @@ table 82572 "ADLSE Companies Table"
         ADLSETable: Record "ADLSE Table";
         ADLSECompaniesTable: Record "ADLSE Companies Table";
         RenameADLSECompaniesTable: Record "ADLSE Companies Table";
-        ADLSESyncCompanies: Record "ADLSE Sync Companies";
+        ADLSESetup: Record "ADLSE Setup";
         SyncCompany: Text[30];
         xSyncCompany: Text[30];
     begin

--- a/businessCentral/app/src/CompanySetup.Page.al
+++ b/businessCentral/app/src/CompanySetup.Page.al
@@ -55,6 +55,11 @@ page 82566 "ADLSE Company Setup"
                     ApplicationArea = All;
                     Editable = false;
                 }
+                field(LandingZone; Rec.LandingZone)
+                {
+                    Caption = 'Landing Zone';
+                    ToolTip = 'Specifies the name of the Landing Zone where the data is going to be uploaded. This Landing Zone you can find at the Replication Status page in Microsoft Fabric.';
+                }
             }
             part("Company Tables"; "ADLSE Company Setup Tables")
             {

--- a/businessCentral/app/src/CompanySetupTables.Page.al
+++ b/businessCentral/app/src/CompanySetupTables.Page.al
@@ -48,6 +48,11 @@ page 82565 "ADLSE Company Setup Tables"
                     Editable = false;
                     ToolTip = 'Specifies the No. of Records for the table.';
                 }
+                field(Include; Rec.Include)
+                {
+                    Caption = 'Include';
+                    ApplicationArea = All;
+                }
                 field(Status; Rec."Last Run State")
                 {
                     ApplicationArea = All;

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -4,13 +4,15 @@ codeunit 82561 "ADLSE Execute"
 {
     Access = Internal;
     TableNo = "ADLSE Table";
-    Permissions = tabledata "ADLSE Table" = rm;
+    Permissions = tabledata "ADLSE Table" = rm, tabledata "ADLSE Companies Table" = rm;
 
     trigger OnRun()
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSERun: Record "ADLSE Run";
         ADLSETable: Record "ADLSE Table";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSECurrentSession: Record "ADLSE Current Session";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSECommunication: Codeunit "ADLSE Communication";
@@ -97,9 +99,16 @@ codeunit 82561 "ADLSE Execute"
 
         //Addin the number when open mirroring is used
         if (ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring") and (ExportSuccess) then begin
-            ADLSETable.Get(Rec."Table ID");
-            ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
-            ADLSETable.Modify(true);
+            ADLSESyncCompanies.Get(CompanyName());
+            if ADLSESyncCompanies.LandingZone <> '' then begin
+                ADLSECompaniesTable.Get(Rec."Table ID", CompanyName());
+                ADLSECompaniesTable.ExportFileNumber := ADLSECompaniesTable.ExportFileNumber + 1;
+                ADLSECompaniesTable.Modify(true);
+            end else begin
+                ADLSETable.Get(Rec."Table ID");
+                ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
+                ADLSETable.Modify(true);
+            end;
         end;
 
         ADLSEExternalEvents.OnAllExportIsFinished(ADLSESetup);
@@ -266,6 +275,8 @@ codeunit 82561 "ADLSE Execute"
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSESetup: Record "ADLSE Setup";
         ADLSETable: Record "ADLSE Table";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSESeekData: Report "ADLSE Seek Data";
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEExecution: Codeunit "ADLSE Execution";
@@ -286,9 +297,16 @@ codeunit 82561 "ADLSE Execute"
             //Addin the number when open mirroring is used
             if DidUpserts then
                 if (ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring") then begin
-                    ADLSETable.Get(TableID);
-                    ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
-                    ADLSETable.Modify(true);
+                    ADLSESyncCompanies.Get(CompanyName());
+                    if ADLSESyncCompanies.LandingZone <> '' then begin
+                        ADLSECompaniesTable.Get(TableID, CompanyName());
+                        ADLSECompaniesTable.ExportFileNumber := ADLSECompaniesTable.ExportFileNumber + 1;
+                        ADLSECompaniesTable.Modify(true);
+                    end else begin
+                        ADLSETable.Get(TableID);
+                        ADLSETable.ExportFileNumber := ADLSETable.ExportFileNumber + 1;
+                        ADLSETable.Modify(true);
+                    end;
                 end;
             RecordRef.Open(ADLSEDeletedRecord."Table ID");
 
@@ -396,6 +414,11 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     procedure ExportSchema(tableId: Integer)
+    begin
+        ExportSchema(tableId, '');
+    end;
+
+    procedure ExportSchema(tableId: Integer; LandingZoneOverride: Text)
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
@@ -416,6 +439,8 @@ codeunit 82561 "ADLSE Execute"
         FieldIdList := CreateFieldListForTable(tableId);
 
         ADLSECommunication.Init(tableId, FieldIdList, UpdatedLastTimestamp, EmitTelemetry);
+        if LandingZoneOverride <> '' then
+            ADLSECommunication.SetLandingZoneOverride(LandingZoneOverride);
 
         if ADLSESetup."Storage Type" <> ADLSESetup."Storage Type"::"Open Mirroring" then //Always export the schema for Open Mirroring
             ADLSECommunication.CheckEntity(CDMDataFormat, EntityJsonNeedsUpdate, ManifestJsonsNeedsUpdate, true)

--- a/businessCentral/app/src/Execution.Codeunit.al
+++ b/businessCentral/app/src/Execution.Codeunit.al
@@ -112,11 +112,15 @@ codeunit 82569 "ADLSE Execution"
         ADLSESetup: Record "ADLSE Setup";
         ADLSETable: Record "ADLSE Table";
         ADLSECurrentSession: Record "ADLSE Current Session";
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
         AllObjWithCaption: Record AllObjWithCaption;
         ADLSEExecute: Codeunit "ADLSE Execute";
         ADLSEExternalEvents: Codeunit "ADLSE External Events";
         ProgressWindowDialog: Dialog;
+        ResolvedLandingZone: Text;
         Progress1Msg: Label 'Current Table:           #1##########\', Comment = '#1: table caption';
+        Progress2Msg: Label 'Company:                 #1##########\Current Table:           #2##########\', Comment = '#1: company name, #2: table caption';
     begin
         // ensure that no current export sessions running
         ADLSECurrentSession.CheckForNoActiveSessions();
@@ -126,20 +130,58 @@ codeunit 82569 "ADLSE Execution"
         if not ADLSETable.FindSet(false) then
             exit;
 
-        if GuiAllowed() then
-            ProgressWindowDialog.Open(Progress1Msg);
+        ADLSESetup.GetSingleton();
 
-        repeat
-            if GuiAllowed() then begin
-                AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
-                AllObjWithCaption.SetRange("Object ID", ADLSETable."Table ID");
-                if AllObjWithCaption.FindFirst() then
+        // For Open Mirroring, export schema to each company's LandingZone
+        if ADLSESetup.GetStorageType() = ADLSESetup."Storage Type"::"Open Mirroring" then begin
+            if GuiAllowed() then
+                ProgressWindowDialog.Open(Progress2Msg);
+
+            if ADLSESyncCompanies.FindSet(false) then
+                repeat
+                    // Resolve LandingZone: company-specific or global fallback
+                    if ADLSESyncCompanies.LandingZone <> '' then
+                        ResolvedLandingZone := ADLSESyncCompanies.LandingZone
+                    else
+                        ResolvedLandingZone := ADLSESetup.LandingZone;
+
                     if GuiAllowed() then
-                        ProgressWindowDialog.Update(1, AllObjWithCaption."Object Caption");
-            end;
+                        ProgressWindowDialog.Update(1, ADLSESyncCompanies."Sync Company");
 
-            ADLSEExecute.ExportSchema(ADLSETable."Table ID");
-        until ADLSETable.Next() = 0;
+                    ADLSETable.FindSet(false);
+                    repeat
+                        // Only export schema for tables included for this company
+                        ADLSECompaniesTable.SetRange("Table ID", ADLSETable."Table ID");
+                        ADLSECompaniesTable.SetRange("Sync Company", ADLSESyncCompanies."Sync Company");
+                        ADLSECompaniesTable.SetRange(Include, true);
+                        if not ADLSECompaniesTable.IsEmpty() then begin
+                            if GuiAllowed() then begin
+                                AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+                                AllObjWithCaption.SetRange("Object ID", ADLSETable."Table ID");
+                                if AllObjWithCaption.FindFirst() then
+                                    ProgressWindowDialog.Update(2, AllObjWithCaption."Object Caption");
+                            end;
+
+                            ADLSEExecute.ExportSchema(ADLSETable."Table ID", ResolvedLandingZone);
+                        end;
+                    until ADLSETable.Next() = 0;
+                until ADLSESyncCompanies.Next() = 0;
+        end else begin
+            // Non-Open Mirroring: existing single-pass behavior
+            if GuiAllowed() then
+                ProgressWindowDialog.Open(Progress1Msg);
+
+            repeat
+                if GuiAllowed() then begin
+                    AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+                    AllObjWithCaption.SetRange("Object ID", ADLSETable."Table ID");
+                    if AllObjWithCaption.FindFirst() then
+                        ProgressWindowDialog.Update(1, AllObjWithCaption."Object Caption");
+                end;
+
+                ADLSEExecute.ExportSchema(ADLSETable."Table ID");
+            until ADLSETable.Next() = 0;
+        end;
 
         if GuiAllowed() then
             ProgressWindowDialog.Close();

--- a/businessCentral/app/src/Gen2Util.Codeunit.al
+++ b/businessCentral/app/src/Gen2Util.Codeunit.al
@@ -344,6 +344,7 @@ codeunit 82568 "ADLSE Gen 2 Util"
         IsHandled: Boolean;
         Response: Text;
         Url: Text;
+        ResolvedLandingZone: Text;
     begin
         // DELETE https://onelake.dfs.fabric.microsoft.com/{CONTAINER_ID}/{MIRRORED_DATABASE_ID}/Files/LandingZone/{FOLDER_NAME}?recursive=true
         // https://learn.microsoft.com/en-us/fabric/database/mirrored-database/open-mirroring-landing-zone-format#drop-table
@@ -353,19 +354,37 @@ codeunit 82568 "ADLSE Gen 2 Util"
         if IsHandled then
             exit;
 
-
         if AllCompanies then begin
+            // Iterate over all sync companies and issue a DELETE for each LandingZone
+            if ADLSESyncCompanies.FindSet(false) then
+                repeat
+                    if ADLSESyncCompanies.LandingZone <> '' then
+                        ResolvedLandingZone := ADLSESyncCompanies.LandingZone
+                    else
+                        ResolvedLandingZone := ADLSESetup.LandingZone;
+
+                    Url := ResolvedLandingZone + '/' + ADLSEntityName + '?recursive=true';
+
+                    Clear(ADLSEHttp);
+                    ADLSEHttp.SetMethod("ADLSE Http Method"::Delete);
+                    ADLSEHttp.SetUrl(Url);
+                    ADLSEHttp.SetAuthorizationCredentials(ADLSECredentials);
+                    ADLSEHttp.InvokeRestApi(Response);
+                until ADLSESyncCompanies.Next() = 0;
+        end else begin
+            // Single company: reset only the current company's LandingZone
             ADLSESyncCompanies.Get(CompanyName());
             if ADLSESyncCompanies.LandingZone <> '' then
-                Url := ADLSESyncCompanies.LandingZone
+                ResolvedLandingZone := ADLSESyncCompanies.LandingZone
             else
-                Url := ADLSESetup.LandingZone;
-            Url += '/' + ADLSEntityName + '?recursive=true';
+                ResolvedLandingZone := ADLSESetup.LandingZone;
+
+            Url := ResolvedLandingZone + '/' + ADLSEntityName + '?recursive=true';
 
             ADLSEHttp.SetMethod("ADLSE Http Method"::Delete);
             ADLSEHttp.SetUrl(Url);
             ADLSEHttp.SetAuthorizationCredentials(ADLSECredentials);
-            ADLSEHttp.InvokeRestApi(Response)
+            ADLSEHttp.InvokeRestApi(Response);
         end;
     end;
 

--- a/businessCentral/app/src/Gen2Util.Codeunit.al
+++ b/businessCentral/app/src/Gen2Util.Codeunit.al
@@ -338,6 +338,7 @@ codeunit 82568 "ADLSE Gen 2 Util"
 
     procedure DropTableFromOpenMirroring(ADLSEntityName: Text; ADLSECredentials: Codeunit "ADLSE Credentials"; AllCompanies: Boolean)
     var
+        ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSESetup: Record "ADLSE Setup";
         ADLSEHttp: Codeunit "ADLSE Http";
         IsHandled: Boolean;
@@ -354,7 +355,11 @@ codeunit 82568 "ADLSE Gen 2 Util"
 
 
         if AllCompanies then begin
-            Url := ADLSESetup.LandingZone;
+            ADLSESyncCompanies.Get(CompanyName());
+            if ADLSESyncCompanies.LandingZone <> '' then
+                Url := ADLSESyncCompanies.LandingZone
+            else
+                Url := ADLSESetup.LandingZone;
             Url += '/' + ADLSEntityName + '?recursive=true';
 
             ADLSEHttp.SetMethod("ADLSE Http Method"::Delete);

--- a/businessCentral/app/src/MultiCompanyExport.Codeunit.al
+++ b/businessCentral/app/src/MultiCompanyExport.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 82579 "ADLSE Multi Company Export"
             Message(ExportStartedTxt, ADLSETable.Count, ADLSESyncCompanies.Count());
         if ADLSESyncCompanies.FindSet(false) then
             repeat
+                IncludeFilterTable := '';
                 GetincludedTableIDFilter(ADLSESyncCompanies, ADLSECompaniesTable);
                 if IncludeFilterTable <> '' then begin
                     ADLSETableFilter.SetRange("Table ID");

--- a/businessCentral/app/src/MultiCompanyExport.Codeunit.al
+++ b/businessCentral/app/src/MultiCompanyExport.Codeunit.al
@@ -7,11 +7,14 @@ codeunit 82579 "ADLSE Multi Company Export"
         ADLSETable: Record "ADLSE Table";
         ADLSESyncCompanies: Record "ADLSE Sync Companies";
         ADLSECurrentSession: Record "ADLSE Current Session";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
         ADLSETableFilter: Record "ADLSE Table" temporary;
         SessionId: Integer;
     begin
-        if FilterTable <> '' then
+        if FilterTable <> '' then begin
             ADLSETableFilter.SetFilter("Table ID", FilterTable);
+            ADLSECompaniesTable.SetFilter("Table ID", FilterTable);
+        end;
         ADLSESyncCompanies.Reset();
         if CompanyFilters <> '' then
             ADLSESyncCompanies.SetFilter("Sync Company", CompanyFilters);
@@ -19,6 +22,11 @@ codeunit 82579 "ADLSE Multi Company Export"
             Message(ExportStartedTxt, ADLSETable.Count, ADLSESyncCompanies.Count());
         if ADLSESyncCompanies.FindSet(false) then
             repeat
+                GetincludedTableIDFilter(ADLSESyncCompanies, ADLSECompaniesTable);
+                if IncludeFilterTable <> '' then begin
+                    ADLSETableFilter.SetRange("Table ID");
+                    ADLSETableFilter.SetFilter("Table ID", IncludeFilterTable);
+                end;
                 Clear(SessionId);
                 if session.StartSession(SessionId, Codeunit::"ADLSE Execution", ADLSESyncCompanies."Sync Company", ADLSETableFilter) then begin
                     ADLSECurrentSession.ChangeCompany(ADLSESyncCompanies."Sync Company");
@@ -33,6 +41,7 @@ codeunit 82579 "ADLSE Multi Company Export"
 
     var
         FilterTable: Text;
+        IncludeFilterTable: Text;
         CompanyFilters: text;
         ExportStartedTxt: Label 'Data export started for %1 tables in %2 Companies. Please refresh this page to see the latest export state for the tables. Only those tables that either have had changes since the last export or failed to export last time have been included. The tables for which the exports could not be started have been queued up for later.', Comment = '%1 = Total number of tables to start the export for. %2 = Total number of companies to export for.';
 
@@ -55,6 +64,19 @@ codeunit 82579 "ADLSE Multi Company Export"
                 if not ActiveSession.IsEmpty then
                     exit(true)
             until ADLSECurrentSession.Next() < 1;
+    end;
+
+    local procedure GetincludedTableIDFilter(var ADLSESyncCompanies: Record "ADLSE Sync Companies"; var ADLSECompaniesTable: Record "ADLSE Companies Table")
+    begin
+        ADLSECompaniesTable.SetRange(Include, true);
+        ADLSECompaniesTable.SetRange("Sync Company", ADLSESyncCompanies."Sync Company");
+        if ADLSECompaniesTable.FindSet(false) then
+            repeat
+                if IncludeFilterTable = '' then
+                    IncludeFilterTable := Format(ADLSECompaniesTable."Table ID")
+                else
+                    IncludeFilterTable := IncludeFilterTable + '|' + Format(ADLSECompaniesTable."Table ID");
+            until ADLSECompaniesTable.Next() < 1;
     end;
 
 

--- a/businessCentral/app/src/Setup.Page.al
+++ b/businessCentral/app/src/Setup.Page.al
@@ -161,6 +161,9 @@ page 82560 "ADLSE Setup"
                     field("Use Friendly Company Name"; Rec."Use Friendly Company Name")
                     {
                     }
+                    field("Set All New Tables Included"; Rec."Set All New Tables Included")
+                    {
+                    }
                 }
             }
             part(Tables; "ADLSE Setup Tables")

--- a/businessCentral/app/src/Setup.Table.al
+++ b/businessCentral/app/src/Setup.Table.al
@@ -246,6 +246,13 @@ table 82560 "ADLSE Setup"
             ToolTip = 'Specifies if the captions of Tables will be used instead of names.';
             InitValue = false;
         }
+        field(96; "Set All New Tables Included"; Boolean)
+        {
+            Caption = 'Set all new tables included';
+            ToolTip = 'Specifies that all new tables will be included for export by default.';
+            DataClassification = ToBeClassified;
+            InitValue = true;
+        }
     }
 
     keys
@@ -291,6 +298,7 @@ table 82560 "ADLSE Setup"
         if Exists() then
             exit;
         "Primary Key" := GetPrimaryKeyValue();
+        "Set All New Tables Included" := true;
         Insert();
     end;
 

--- a/businessCentral/app/src/SyncCompanies.Table.al
+++ b/businessCentral/app/src/SyncCompanies.Table.al
@@ -22,6 +22,11 @@ table 82573 "ADLSE Sync Companies"
         {
             Caption = 'Landing Zone';
             ToolTip = 'Specifies the name of the Landing Zone where the data is going to be uploaded. This Landing Zone you can find at the Replication Status page in Microsoft Fabric.';
+
+            trigger OnValidate()
+            begin
+                CheckLandingZoneChange();
+            end;
         }
 
     }
@@ -37,6 +42,7 @@ table 82573 "ADLSE Sync Companies"
     trigger OnInsert()
     var
     begin
+        CheckLandingZoneChange();
         UpsertAllTableIds(0);
     end;
 
@@ -49,6 +55,7 @@ table 82573 "ADLSE Sync Companies"
     trigger OnModify()
     var
     begin
+        CheckLandingZoneChange();
         UpsertAllTableIds(1);
     end;
 
@@ -101,5 +108,17 @@ table 82573 "ADLSE Sync Companies"
                         until ADLSECompaniesTable.Next() < 1;
                 end;
         end;
+    end;
+
+    local procedure CheckLandingZoneChange()
+    var
+        SyncCompanies: Record "ADLSE Sync Companies";
+    begin
+        if Rec.LandingZone = '' then
+            exit;
+        SyncCompanies.SetRange(LandingZone, Rec.LandingZone);
+        SyncCompanies.SetFilter("Sync Company", '<>%1', Rec."Sync Company");
+        if not SyncCompanies.IsEmpty() then
+            Error('Landing Zone ''%1'' is already assigned to another company.', Rec.LandingZone);
     end;
 }

--- a/businessCentral/app/src/SyncCompanies.Table.al
+++ b/businessCentral/app/src/SyncCompanies.Table.al
@@ -18,6 +18,11 @@ table 82573 "ADLSE Sync Companies"
             Caption = 'Sync Company';
             TableRelation = Company.Name where("Evaluation Company" = const(false));
         }
+        field(32; LandingZone; Text[250])
+        {
+            Caption = 'Landing Zone';
+            ToolTip = 'Specifies the name of the Landing Zone where the data is going to be uploaded. This Landing Zone you can find at the Replication Status page in Microsoft Fabric.';
+        }
 
     }
 

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -216,6 +216,7 @@ table 82561 "ADLSE Table"
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSESetup: Record "ADLSE Setup";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
         Company: Record Company;
         ADLSECommunication: Codeunit "ADLSE Communication";
         Counter: Integer;
@@ -265,6 +266,17 @@ table 82561 "ADLSE Table"
 
                 if (ADLSESetup."Delete Table") then
                     ADLSECommunication.ResetTableExport(Rec."Table ID", AllCompanies);
+
+                // Reset ExportFileNumber per-company for Open Mirroring
+                if ADLSESetup."Storage Type" = ADLSESetup."Storage Type"::"Open Mirroring" then
+                    if AllCompanies then begin
+                        ADLSECompaniesTable.SetRange("Table ID", Rec."Table ID");
+                        ADLSECompaniesTable.ModifyAll(ExportFileNumber, 1);
+                    end else
+                        if ADLSECompaniesTable.Get(Rec."Table ID", CompanyName()) then begin
+                            ADLSECompaniesTable.ExportFileNumber := 1;
+                            ADLSECompaniesTable.Modify(true);
+                        end;
 
                 Rec.ExportFileNumber := 1;
                 Rec.Modify(true);
@@ -361,14 +373,15 @@ table 82561 "ADLSE Table"
     var
         ADLSECompaniesTable: Record "ADLSE Companies Table";
         ADLSESyncCompanies: Record "ADLSE Sync Companies";
+        ADLSESetup: Record "ADLSE Setup";
         SyncCompany: Text[30];
     begin
         // Rowmarker semantics used here:
         // 0 = Insert -> add missing rows for this Sync Company across ALL table IDs (do not update existing rows)
         // 1 = Modify -> update existing rows for this Sync Company across ALL table IDs (do not insert missing rows)
         // 2 = Delete -> remove ALL rows for this Sync Company across ALL table IDs (except current row already being deleted)
-
-        SyncCompany := CompanyName;
+        ADLSESetup.GetSingleton();
+        SyncCompany := CopyStr(CompanyName, 1, MaxStrLen(SyncCompany));
         if SyncCompany = '' then
             exit;
 
@@ -385,6 +398,7 @@ table 82561 "ADLSE Table"
                         ADLSECompaniesTable.Init();
                         ADLSECompaniesTable."Table ID" := Rec."Table ID";
                         ADLSECompaniesTable."Sync Company" := ADLSESyncCompanies."Sync Company";
+                        ADLSECompaniesTable.Include := ADLSESetup."Set All New Tables Included";
                         if ADLSECompaniesTable.Insert(false) then;
                     until ADLSESyncCompanies.Next() = 0;
             8: // Rename: 

--- a/businessCentral/app/src/Upgrade.Codeunit.al
+++ b/businessCentral/app/src/Upgrade.Codeunit.al
@@ -26,6 +26,7 @@ codeunit 82572 "ADLSE Upgrade"
         ContainerFieldFromIsolatedStorageToSetupField();
         SeperateSchemaAndData();
         CopyValuesFromExportCategoryToExportcategoryTable();
+        MigrateExportFileNumberToCompaniesTable();
     end;
 
     var
@@ -157,5 +158,45 @@ codeunit 82572 "ADLSE Upgrade"
     procedure GetCopyValuesFromExportCategoryToExportcategoryTableUpgradeTag(): Code[250]
     begin
         exit('GITHUB-225-CopyValuesFromExportCategoryToExportcategoryTable-20250121');
+    end;
+
+    local procedure MigrateExportFileNumberToCompaniesTable()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if UpgradeTag.HasUpgradeTag(GetMigrateExportFileNumberToCompaniesTableUpgradeTag()) then
+            exit;
+        DoMigrateExportFileNumberToCompaniesTable();
+        UpgradeTag.SetUpgradeTag(GetMigrateExportFileNumberToCompaniesTableUpgradeTag());
+    end;
+
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Companies Table", 'rm')]
+    local procedure DoMigrateExportFileNumberToCompaniesTable()
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSETable: Record "ADLSE Table";
+        ADLSECompaniesTable: Record "ADLSE Companies Table";
+    begin
+        ADLSESetup.GetOrCreate();
+        ADLSESetup."Set All New Tables Included" := true;
+        ADLSESetup.Modify();
+        // Copy the ExportFileNumber from each ADLSE Table record to all matching
+        // ADLSE Companies Table records so each company gets its own counter.
+        if ADLSETable.FindSet() then
+            repeat
+                ADLSECompaniesTable.SetRange("Table ID", ADLSETable."Table ID");
+                if ADLSECompaniesTable.FindSet(true) then
+                    repeat
+                        if ADLSECompaniesTable.ExportFileNumber = 0 then begin
+                            ADLSECompaniesTable.ExportFileNumber := ADLSETable.ExportFileNumber;
+                            ADLSECompaniesTable.Modify(false);
+                        end;
+                    until ADLSECompaniesTable.Next() = 0;
+            until ADLSETable.Next() = 0;
+    end;
+
+    procedure GetMigrateExportFileNumberToCompaniesTableUpgradeTag(): Code[250]
+    begin
+        exit('BC2ADLS-ExportFileNumberToCompaniesTable-20250603');
     end;
 }

--- a/businessCentral/app/src/UpgradeTagNewCompanySubs.Codeunit.al
+++ b/businessCentral/app/src/UpgradeTagNewCompanySubs.Codeunit.al
@@ -12,5 +12,6 @@ codeunit 82575 "ADLSE UpgradeTagNewCompanySubs"
     begin
         PerCompanyUpgradeTags.Add(ADLSEUpgrade.GetRetenPolLogEntryAddedUpgradeTag());
         PerCompanyUpgradeTags.Add(ADLSEUpgrade.GetContainerFieldFromIsolatedStorageToSetupFieldUpgradeTag());
+        PerCompanyUpgradeTags.Add(ADLSEUpgrade.GetMigrateExportFileNumberToCompaniesTableUpgradeTag());
     end;
 }


### PR DESCRIPTION
Enhance the BC2ADLS system to allow each company to export a unique list of tables to its own Fabric workspace. This update introduces new fields for managing individual table exports and ensures that all updates are handled by a single job queue. The implementation includes modifications to the setup, company, and sync tables to accommodate the new functionality.

Resolves #8